### PR TITLE
New custom dyanmic templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,61 @@ private def raise_missing_key_message
 end
 ```
 
+### Sending Dynamic Template emails
+
+SendGrid allows you to use [Dynamic Transactional Templates](https://docs.sendgrid.com/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates) when
+sending your emails. These templates are designed and created inside of the
+SendGrid website.
+
+This shard allows you to use the dynamic templates in place of building
+the HTML and Text temapltes in your application.
+
+You must define `template_id`, and `dynamic_template_data` methods in your
+email class that will use the dynamic template.
+
+1. Login to SendGrid
+2. Select Email API > Dynamic Templates
+3. Create a new template
+4. Copy the "Template-ID" value for that template.
+5. Update your email class
+
+```crystal
+# Using built-in templates
+class WelcomeEmail < BaseEmail
+  def initialize(@user : User)
+  end
+
+  to @user
+  subject "Welcome - Confirm Your Email"
+  templates html, text
+end
+```
+
+```crystal
+# Using dynamic templates
+class WelcomeEmail < BaseEmail
+  def initialize(@user : User)
+  end
+
+  # This must be the String value of your ID
+  def template_id
+    "d-12345abcd6543dcbaffeedd1122aabb"
+  end
+
+  # This is optional. Define a Hash with your
+  # custom handlebars variables
+  def dynamic_template_data
+    {
+      "username" => @user.username,
+      "confirmEmailUrl" => "https://myapp.com/confirm?token=..."
+    }
+  end
+
+  to @user
+  subject "Welcome - Confirm Your Email"
+end
+```
+
 ## Contributing
 
 1. Fork it (<https://github.com/your-github-user/carbon_sendgrid_adapter/fork>)

--- a/README.md
+++ b/README.md
@@ -48,11 +48,8 @@ SendGrid allows you to use [Dynamic Transactional Templates](https://docs.sendgr
 sending your emails. These templates are designed and created inside of the
 SendGrid website.
 
-This shard allows you to use the dynamic templates in place of building
-the HTML and Text temapltes in your application.
-
-You must define `template_id`, and `dynamic_template_data` methods in your
-email class that will use the dynamic template.
+Define a `template_id`, and `dynamic_template_data` method in your
+email class to use the dynamic template.
 
 1. Login to SendGrid
 2. Select Email API > Dynamic Templates
@@ -96,6 +93,9 @@ class WelcomeEmail < BaseEmail
   subject "Welcome - Confirm Your Email"
 end
 ```
+
+NOTE: SendGrid requires you to either define `template_id` or use the `templates` macro
+to generate an email body content.
 
 ## Contributing
 

--- a/spec/carbon_sendgrid_adapter_spec.cr
+++ b/spec/carbon_sendgrid_adapter_spec.cr
@@ -107,6 +107,30 @@ describe Carbon::SendGridAdapter do
         {type: "text/html", value: "html"},
       ]
     end
+
+    it "allows for a custom template_id" do
+      custom_email = CustomTemplateEmail.new
+      params = Carbon::SendGridAdapter::Email.new(custom_email, api_key: "fake_key").params
+
+      params[:template_id].should eq("welcome-abc-123")
+
+      normal_email = FakeEmail.new
+      params = Carbon::SendGridAdapter::Email.new(normal_email, api_key: "fake_key").params
+
+      params[:template_id].should eq(nil)
+    end
+
+    it "allows for custom template data" do
+      custom_email = CustomTemplateEmail.new
+      params = Carbon::SendGridAdapter::Email.new(custom_email, api_key: "fake_key").params
+
+      params[:personalizations].first[:dynamic_template_data].should_not eq(nil)
+
+      normal_email = FakeEmail.new
+      params = Carbon::SendGridAdapter::Email.new(normal_email, api_key: "fake_key").params
+
+      params[:personalizations].first.has_key?(:dynamic_template_data).should eq(false)
+    end
   end
 end
 

--- a/spec/carbon_sendgrid_adapter_spec.cr
+++ b/spec/carbon_sendgrid_adapter_spec.cr
@@ -16,32 +16,42 @@ describe Carbon::SendGridAdapter do
     end
   {% end %}
 
+  describe "errors" do
+    it "raises SendGridInvalidTemplateError if no template is defined in params" do
+      expect_raises(Carbon::SendGridInvalidTemplateError) do
+        email = FakeEmail.new
+        Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").params
+      end
+    end
+  end
+
   describe "params" do
     it "is not sandboxed by default" do
-      params_for[:mail_settings][:sandbox_mode][:enable].should be_false
+      settings = params_for(text_body: "0")["mail_settings"].as(NamedTuple)
+      settings[:sandbox_mode][:enable].should be_false
     end
 
     it "handles headers" do
       headers = {"Header1" => "value1", "Header2" => "value2"}
-      params = params_for(headers: headers)
+      params = params_for(headers: headers, text_body: "0")
 
-      params[:headers].should eq headers
+      params["headers"].should eq headers
     end
 
     it "sets extracts reply-to header" do
       headers = {"reply-to" => "noreply@badsupport.com", "Header" => "value"}
-      params = params_for(headers: headers)
+      params = params_for(headers: headers, text_body: "0")
 
-      params[:headers].should eq({"Header" => "value"})
-      params[:reply_to].should eq({email: "noreply@badsupport.com"})
+      params["headers"].should eq({"Header" => "value"})
+      params["reply_to"].should eq({"email" => "noreply@badsupport.com"})
     end
 
     it "sets extracts reply-to header regardless of case" do
       headers = {"Reply-To" => "noreply@badsupport.com", "Header" => "value"}
-      params = params_for(headers: headers)
+      params = params_for(headers: headers, text_body: "0")
 
-      params[:headers].should eq({"Header" => "value"})
-      params[:reply_to].should eq({email: "noreply@badsupport.com"})
+      params["headers"].should eq({"Header" => "value"})
+      params["reply_to"].should eq({"email" => "noreply@badsupport.com"})
     end
 
     it "sets personalizations" do
@@ -55,25 +65,26 @@ describe Carbon::SendGridAdapter do
       recipient_params = params_for(
         to: [to_without_name, to_with_name],
         cc: [cc_without_name, cc_with_name],
-        bcc: [bcc_without_name, bcc_with_name]
-      )[:personalizations].first
+        bcc: [bcc_without_name, bcc_with_name],
+        text_body: "0"
+      )["personalizations"].as(Array).first
 
-      recipient_params[:to].should eq(
+      recipient_params["to"].should eq(
         [
-          {name: nil, email: "to@example.com"},
-          {name: "Jimmy", email: "to2@example.com"},
+          {"email" => "to@example.com"},
+          {"name" => "Jimmy", "email" => "to2@example.com"},
         ]
       )
-      recipient_params[:cc].should eq(
+      recipient_params["cc"].should eq(
         [
-          {name: nil, email: "cc@example.com"},
-          {name: "Kim", email: "cc2@example.com"},
+          {"email" => "cc@example.com"},
+          {"name" => "Kim", "email" => "cc2@example.com"},
         ]
       )
-      recipient_params[:bcc].should eq(
+      recipient_params["bcc"].should eq(
         [
-          {name: nil, email: "bcc@example.com"},
-          {name: "James", email: "bcc2@example.com"},
+          {"email" => "bcc@example.com"},
+          {"name" => "James", "email" => "bcc2@example.com"},
         ]
       )
     end
@@ -81,30 +92,30 @@ describe Carbon::SendGridAdapter do
     it "removes empty recipients from personalizations" do
       to_without_name = Carbon::Address.new("to@example.com")
 
-      recipient_params = params_for(to: [to_without_name])[:personalizations].first
+      recipient_params = params_for(to: [to_without_name], text_body: "0")["personalizations"].as(Array).first
 
-      recipient_params.keys.should eq [:to]
-      recipient_params[:to].should eq [{name: nil, email: "to@example.com"}]
+      recipient_params.keys.should eq ["to"]
+      recipient_params["to"].should eq [{"email" => "to@example.com"}]
     end
 
     it "sets the subject" do
-      params_for(subject: "My subject")[:subject].should eq "My subject"
+      params_for(subject: "My subject", text_body: "0")["subject"].should eq "My subject"
     end
 
     it "sets the from address" do
       address = Carbon::Address.new("from@example.com")
-      params_for(from: address)[:from].should eq({email: "from@example.com"}.to_h)
+      params_for(from: address, text_body: "0")["from"].should eq({"email" => "from@example.com"})
 
       address = Carbon::Address.new("Sally", "from@example.com")
-      params_for(from: address)[:from].should eq({name: "Sally", email: "from@example.com"}.to_h)
+      params_for(from: address, text_body: "0")["from"].should eq({"name" => "Sally", "email" => "from@example.com"})
     end
 
     it "sets the content" do
-      params_for(text_body: "text")[:content].should eq [{type: "text/plain", value: "text"}]
-      params_for(html_body: "html")[:content].should eq [{type: "text/html", value: "html"}]
-      params_for(text_body: "text", html_body: "html")[:content].should eq [
-        {type: "text/plain", value: "text"},
-        {type: "text/html", value: "html"},
+      params_for(text_body: "text")["content"].should eq [{"type" => "text/plain", "value" => "text"}]
+      params_for(html_body: "html")["content"].should eq [{"type" => "text/html", "value" => "html"}]
+      params_for(text_body: "text", html_body: "html")["content"].should eq [
+        {"type" => "text/plain", "value" => "text"},
+        {"type" => "text/html", "value" => "html"},
       ]
     end
 
@@ -112,24 +123,24 @@ describe Carbon::SendGridAdapter do
       custom_email = CustomTemplateEmail.new
       params = Carbon::SendGridAdapter::Email.new(custom_email, api_key: "fake_key").params
 
-      params[:template_id].should eq("welcome-abc-123")
+      params["template_id"].should eq("welcome-abc-123")
 
-      normal_email = FakeEmail.new
+      normal_email = FakeEmail.new(text_body: "0")
       params = Carbon::SendGridAdapter::Email.new(normal_email, api_key: "fake_key").params
 
-      params[:template_id].should eq(nil)
+      params.has_key?("template_id").should eq(false)
     end
 
     it "allows for custom template data" do
       custom_email = CustomTemplateEmail.new
       params = Carbon::SendGridAdapter::Email.new(custom_email, api_key: "fake_key").params
 
-      params[:personalizations].first[:dynamic_template_data].should_not eq(nil)
+      params["personalizations"].as(Array).first["dynamic_template_data"].should_not eq(nil)
 
-      normal_email = FakeEmail.new
+      normal_email = FakeEmail.new(text_body: "0")
       params = Carbon::SendGridAdapter::Email.new(normal_email, api_key: "fake_key").params
 
-      params[:personalizations].first.has_key?(:dynamic_template_data).should eq(false)
+      params["personalizations"].as(Array).first.has_key?("dynamic_template_data").should eq(false)
     end
   end
 end

--- a/spec/support/custom_template_email.cr
+++ b/spec/support/custom_template_email.cr
@@ -1,0 +1,53 @@
+class CustomTemplateEmail < Carbon::Email
+  def initialize(
+    @from = Carbon::Address.new("from@example.com"),
+    @to = [] of Carbon::Address,
+    @cc = [] of Carbon::Address,
+    @bcc = [] of Carbon::Address,
+    @headers = {} of String => String,
+    @subject = "subject",
+    @text_body : String? = nil,
+    @html_body : String? = nil
+  )
+  end
+
+  def template_id
+    "welcome-abc-123"
+  end
+
+  def dynamic_template_data
+    {
+      "total" => "$ 239.85",
+      "items" => [
+        {
+          "text"  => "New Line Sneakers",
+          "image" => "https://marketing-image-production.s3.amazonaws.com/uploads/8dda1131320a6d978b515cc04ed479df259a458d5d45d58b6b381cae0bf9588113e80ef912f69e8c4cc1ef1a0297e8eefdb7b270064cc046b79a44e21b811802.png",
+          "price" => "$ 79.95",
+        },
+        {
+          "text"  => "Old Line Sneakers",
+          "image" => "https://marketing-image-production.s3.amazonaws.com/uploads/3629f54390ead663d4eb7c53702e492de63299d7c5f7239efdc693b09b9b28c82c924225dcd8dcb65732d5ca7b7b753c5f17e056405bbd4596e4e63a96ae5018.png",
+          "price" => "$ 79.95",
+        },
+        {
+          "text"  => "Blue Line Sneakers",
+          "image" => "https://marketing-image-production.s3.amazonaws.com/uploads/00731ed18eff0ad5da890d876c456c3124a4e44cb48196533e9b95fb2b959b7194c2dc7637b788341d1ff4f88d1dc88e23f7e3704726d313c57f350911dd2bd0.png",
+          "price" => "$ 79.95",
+        },
+      ],
+      "receipt"   => true,
+      "name"      => "Sample Name",
+      "address01" => "1234 Fake St.",
+      "address02" => "Apt. 123",
+      "city"      => "Place",
+      "state"     => "CO",
+      "zip"       => "80202",
+    }
+  end
+
+  from @from
+  to @to
+  cc @cc
+  bcc @bcc
+  subject @subject
+end

--- a/src/carbon_sendgrid_adapter.cr
+++ b/src/carbon_sendgrid_adapter.cr
@@ -1,6 +1,7 @@
 require "http"
 require "json"
 require "carbon"
+require "./carbon_sendgrid_extensions"
 
 class Carbon::SendGridAdapter < Carbon::Adapter
   private getter api_key : String
@@ -40,6 +41,7 @@ class Carbon::SendGridAdapter < Carbon::Adapter
         content:          content,
         headers:          headers,
         reply_to:         reply_to_params,
+        template_id:      email.template_id,
         mail_settings:    {sandbox_mode: {enable: sandbox?}},
       }
     end
@@ -68,11 +70,12 @@ class Carbon::SendGridAdapter < Carbon::Adapter
 
     private def personalizations
       {
-        to:  to_send_grid_address(email.to),
-        cc:  to_send_grid_address(email.cc),
-        bcc: to_send_grid_address(email.bcc),
+        to:                    to_send_grid_address(email.to),
+        cc:                    to_send_grid_address(email.cc),
+        bcc:                   to_send_grid_address(email.bcc),
+        dynamic_template_data: email.dynamic_template_data,
       }.to_h.reject do |_key, value|
-        value.empty?
+        value.nil? || value.empty?
       end
     end
 

--- a/src/carbon_sendgrid_extensions.cr
+++ b/src/carbon_sendgrid_extensions.cr
@@ -1,0 +1,24 @@
+# https://docs.sendgrid.com/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates
+module Carbon::SendGridExtensions
+  # Define the dynamic template_id to use
+  # when sending an email. This will be a
+  # String value of the template defined
+  # in SendGrid. If `nil`, then use the
+  # Carbon template system.
+  def template_id
+    nil
+  end
+
+  # Define the dynamic data to be replaced
+  # in your email template. This should be a
+  # dynamic Hash(String, Any) where the keys
+  # must match with your template values.
+  # If `nil`, then no data is sent.
+  def dynamic_template_data
+    nil
+  end
+end
+
+class Carbon::Email
+  include Carbon::SendGridExtensions
+end

--- a/src/errors.cr
+++ b/src/errors.cr
@@ -1,0 +1,14 @@
+module Carbon
+  class CarbonError < Exception
+  end
+
+  # Raised if your email is missing both `template_id`
+  # and `templates`.
+  class SendGridInvalidTemplateError < CarbonError
+  end
+
+  # Raised if the response from SendGrid is not
+  # successful
+  class SendGridResponseFailedError < CarbonError
+  end
+end


### PR DESCRIPTION
This adds in the ability for an email to specify a Dynamic Template https://docs.sendgrid.com/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates

Dynamic templates are designed and created within the SendGrid website itself. The template builder allows you to specify handlebar type variable placeholders. In the API, you send the `template_id`, and the `dynamic_template_data` hash, and SendGrid compiles the email for you to send that.

To use this feature, you would just define two specific methods in your email.

```crystal
class NotifierEmail < BaseEmail
  def initialize(@user : User)
  end

  def template_id
    "the-special-id-in-sendgrid"
  end

  def dynamic_template_data
    {
      "username" => @user.username,
      "unsub_token" => @user.unsubscribe_token
    }
  end

  to @user
  subject "Notification"
  # note `templates` isn't specified here...
end

NotifierEmail.new(current_user).deliver_now
```


Since this is pretty custom to SendGrid, I couldn't see a way to make it more generic to be a Carbon specific feature. 