### PR TITLE
Release 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,14 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 0.36.1
           - 1.0.0
+          - 1.1.0
+          - 1.2.0
         experimental:
           - false
+        include:
+          crystal_version: nightly
+          experimental: true
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     steps:
@@ -35,10 +39,14 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 0.36.1
           - 1.0.0
+          - 1.1.0
+          - 1.2.0
         experimental:
           - false
+        include:
+          crystal_version: nightly
+          experimental: true
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     steps:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ to generate an email body content.
 
 ## Contributing
 
-1. Fork it (<https://github.com/your-github-user/carbon_sendgrid_adapter/fork>)
+1. Fork it (<https://github.com/luckyframework/carbon_sendgrid_adapter/fork>)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/shard.yml
+++ b/shard.yml
@@ -1,10 +1,10 @@
 name: carbon_sendgrid_adapter
-version: 0.1.0
+version: 0.2.0
 
 authors:
   - Matthew McGarvey <matthewmcgarvey14@gmail.com>
 
-crystal: '>= 0.36.1, < 2.0.0'
+crystal: '>= 1.0.0'
 
 license: MIT
 

--- a/src/carbon_sendgrid_adapter.cr
+++ b/src/carbon_sendgrid_adapter.cr
@@ -5,6 +5,7 @@ require "./errors"
 require "./carbon_sendgrid_extensions"
 
 class Carbon::SendGridAdapter < Carbon::Adapter
+  VERSION = "0.2.0"
   private getter api_key : String
   private getter? sandbox : Bool
 

--- a/src/version.cr
+++ b/src/version.cr
@@ -1,3 +1,0 @@
-module CarbonSendgridAdapter
-  VERSION = "0.1.0"
-end


### PR DESCRIPTION
This bumps the CI to drop Crystal 0.36 support, and just focus on later versions (including nightly). Also, the version file wasn't really used (even named wrong), so I've just removed it and moved the constant up. 