### PR TITLE
Adding support for passing over unsubscribe data.

### DIFF
--- a/spec/carbon_sendgrid_adapter_spec.cr
+++ b/spec/carbon_sendgrid_adapter_spec.cr
@@ -142,6 +142,18 @@ describe Carbon::SendGridAdapter do
 
       params["personalizations"].as(Array).first.has_key?("dynamic_template_data").should eq(false)
     end
+
+    it "passes over asm data on how to handle unsubscribes" do
+      custom_email = CustomTemplateEmail.new
+      params = Carbon::SendGridAdapter::Email.new(custom_email, api_key: "fake_key").params
+
+      params["personalizations"].as(Array).first["dynamic_template_data"].should_not eq(nil)
+
+      email = FakeEmail.new(text_body: "0")
+      params = Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").params
+
+      params["personalizations"].as(Array).first.has_key?("asm").should eq(false)
+    end
   end
 end
 

--- a/spec/support/custom_template_email.cr
+++ b/spec/support/custom_template_email.cr
@@ -15,6 +15,13 @@ class CustomTemplateEmail < Carbon::Email
     "welcome-abc-123"
   end
 
+  def asm_data
+    {
+      "group_id"          => "12345",
+      "groups_to_display" => ["12345"],
+    }
+  end
+
   def dynamic_template_data
     {
       "total" => "$ 239.85",

--- a/src/carbon_sendgrid_adapter.cr
+++ b/src/carbon_sendgrid_adapter.cr
@@ -43,6 +43,7 @@ class Carbon::SendGridAdapter < Carbon::Adapter
         "from"             => from,
         "headers"          => headers,
         "reply_to"         => reply_to_params,
+        "asm"              => asm_data,
         "mail_settings"    => {sandbox_mode: {enable: sandbox?}},
       }.compact
 
@@ -116,6 +117,12 @@ class Carbon::SendGridAdapter < Carbon::Adapter
 
     private def from : Hash(String, String)
       to_send_grid_address([email.from]).first
+    end
+
+    private def asm_data : Hash(String, String)?
+      if asm_data = email.asm
+        {"asm" => asm_data}
+      end
     end
 
     private def content : Array(Hash(String, String))

--- a/src/carbon_sendgrid_extensions.cr
+++ b/src/carbon_sendgrid_extensions.cr
@@ -17,6 +17,13 @@ module Carbon::SendGridExtensions
   def dynamic_template_data
     nil
   end
+
+  # Define the group ids to determine how to
+  # handle unsubscribes.
+  # https://docs.sendgrid.com/ui/sending-email/unsubscribe-groups
+  def asm
+    nil
+  end
 end
 
 class Carbon::Email


### PR DESCRIPTION
https://docs.sendgrid.com/ui/sending-email/unsubscribe-groups

This is used for letting sendgrid handle the unsubscribe form based on
what you pass over in this field.