### PR TITLE
Lock to Crystal 1.4 or later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 1.0.0
-          - 1.1.0
-          - 1.2.0
+          - latest
         experimental:
           - false
         include:
@@ -25,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Crystal
-        uses: oprypin/install-crystal@v1
+        uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{ matrix.crystal_version }}
       - name: Install shards
@@ -39,9 +37,8 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 1.0.0
-          - 1.1.0
-          - 1.2.0
+          - 1.4.0
+          - latest
         experimental:
           - false
         include:
@@ -52,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Crystal
-        uses: oprypin/install-crystal@v1
+        uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{ matrix.crystal_version }}
       - name: Install shards

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.2.1
 authors:
   - Matthew McGarvey <matthewmcgarvey14@gmail.com>
 
-crystal: '>= 1.0.0'
+crystal: '>= 1.4.0'
 
 license: MIT
 
@@ -22,4 +22,4 @@ development_dependencies:
     version: ~> 0.1.1
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.2
+    version: ~> 1.0.0


### PR DESCRIPTION
# Purpose

Locks Lucky to Crystal version 1.4.0 or later.
# Description

With the release of the new Crystal book being focused on 1.4.0, and shards like Ameba locking to that version, as well as Crystal 1.5.0 is slated to come out in the next 2 months, it makes sense that we start pushing to have everyone use a later version of Crystal. This will also allow us to clean up some code with the assumption that the user is using 1.4.0 or later.
