### PR TITLE
Update to latest Carbon. Added support for attachments.

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,7 +11,7 @@ license: MIT
 dependencies:
   carbon:
     github: luckyframework/carbon
-    version: ~> 0.4.0
+    version: ~> 0.5.1
   habitat:
     github: luckyframework/habitat
     version: ~> 0.4.8

--- a/spec/carbon_sendgrid_adapter_spec.cr
+++ b/spec/carbon_sendgrid_adapter_spec.cr
@@ -154,6 +154,15 @@ describe Carbon::SendGridAdapter do
 
       params["personalizations"].as(Array).first.has_key?("asm").should eq(false)
     end
+
+    it "handles attachments" do
+      email = FakeEmail.new(text_body: "0")
+      params = Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").params
+      attachments = params["attachments"].as(Array)
+      attachments.size.should eq(1)
+      attachments.first["filename"].should eq("contract.pdf")
+      Base64.decode_string(attachments.first["content"].to_s).should eq("Sign here")
+    end
   end
 end
 

--- a/spec/support/fake_email.cr
+++ b/spec/support/fake_email.cr
@@ -18,4 +18,13 @@ class FakeEmail < Carbon::Email
   cc @cc
   bcc @bcc
   subject @subject
+  attachment contract
+
+  def contract
+    {
+      io:        IO::Memory.new("Sign here"),
+      file_name: "contract.pdf",
+      mime_type: "application/pdf",
+    }
+  end
 end


### PR DESCRIPTION
Ref #13

Now that Carbon has some [support for attachments](https://github.com/luckyframework/carbon/pull/88) I need to update this shard so we can do a release. I followed the [SMTP](https://github.com/luckyframework/carbon_smtp_adapter/pull/20) update for attachment and used the Sendgrid docs https://docs.sendgrid.com/api-reference/mail-send/mail-send to mimic the structure.