### PR TITLE
feat: add categories and send_at support

### DIFF
--- a/spec/carbon_sendgrid_adapter_spec.cr
+++ b/spec/carbon_sendgrid_adapter_spec.cr
@@ -18,10 +18,10 @@ describe Carbon::SendGridAdapter do
   {% end %}
 
   describe "errors" do
-    it "raises SendGridInvalidTemplateError if no template is defined in params" do
+    it "raises SendGridInvalidTemplateError if no template is defined" do
       expect_raises(Carbon::SendGridInvalidTemplateError) do
         email = FakeEmail.new
-        Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").params
+        Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").sendgrid_options
       end
     end
   end
@@ -112,24 +112,24 @@ describe Carbon::SendGridAdapter do
     end
 
     it "sets the content" do
-      params_for(text_body: "text")["content"].should eq [{"type" => "text/plain", "value" => "text"}]
-      params_for(html_body: "html")["content"].should eq [{"type" => "text/html", "value" => "html"}]
-      params_for(text_body: "text", html_body: "html")["content"].should eq [
+      sendgrid_options_for(text_body: "text")["content"].should eq JSON.parse([{"type" => "text/plain", "value" => "text"}].to_json)
+      sendgrid_options_for(html_body: "html")["content"].should eq JSON.parse([{"type" => "text/html", "value" => "html"}].to_json)
+      sendgrid_options_for(text_body: "text", html_body: "html")["content"].should eq JSON.parse([
         {"type" => "text/plain", "value" => "text"},
         {"type" => "text/html", "value" => "html"},
-      ]
+      ].to_json)
     end
 
     it "allows for a custom template_id" do
       custom_email = CustomTemplateEmail.new
-      params = Carbon::SendGridAdapter::Email.new(custom_email, api_key: "fake_key").params
+      options = Carbon::SendGridAdapter::Email.new(custom_email, api_key: "fake_key").sendgrid_options
 
-      params["template_id"].should eq("welcome-abc-123")
+      options["template_id"].should eq(JSON::Any.new("welcome-abc-123"))
 
       normal_email = FakeEmail.new(text_body: "0")
-      params = Carbon::SendGridAdapter::Email.new(normal_email, api_key: "fake_key").params
+      options = Carbon::SendGridAdapter::Email.new(normal_email, api_key: "fake_key").sendgrid_options
 
-      params.has_key?("template_id").should eq(false)
+      options.has_key?("template_id").should eq(false)
     end
 
     it "allows for custom template data" do
@@ -146,14 +146,14 @@ describe Carbon::SendGridAdapter do
 
     it "passes over asm data on how to handle unsubscribes" do
       custom_email = CustomTemplateEmail.new
-      params = Carbon::SendGridAdapter::Email.new(custom_email, api_key: "fake_key").params
+      options = Carbon::SendGridAdapter::Email.new(custom_email, api_key: "fake_key").sendgrid_options
 
-      params["personalizations"].as(Array).first["dynamic_template_data"].should_not eq(nil)
+      options["asm"].should eq(JSON.parse({"group_id" => 1234, "groups_to_display" => [1234]}.to_json))
 
       email = FakeEmail.new(text_body: "0")
-      params = Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").params
+      options = Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").sendgrid_options
 
-      params["personalizations"].as(Array).first.has_key?("asm").should eq(false)
+      options.has_key?("asm").should eq(false)
     end
 
     it "handles attachments" do
@@ -166,32 +166,61 @@ describe Carbon::SendGridAdapter do
     end
 
     describe "sendgrid specific features" do
-      it "includes categories in extra_params when defined" do
+      it "includes categories in sendgrid_options when defined" do
         email = EmailWithSendGridFeatures.new(text_body: "0")
-        extra = Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").extra_params
+        options = Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").sendgrid_options
 
-        extra["categories"].should eq(["welcome", "onboarding", "transactional"])
+        options["categories"].should eq(JSON.parse(["welcome", "onboarding", "transactional"].to_json))
       end
 
       it "does not include categories when not defined" do
         email = FakeEmail.new(text_body: "0")
-        extra = Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").extra_params
+        options = Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").sendgrid_options
 
-        extra.has_key?("categories").should eq(false)
+        options.has_key?("categories").should eq(false)
       end
 
-      it "includes send_at in extra_params when defined" do
+      it "includes send_at in sendgrid_options when defined" do
         email = EmailWithSendGridFeatures.new(text_body: "0")
-        extra = Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").extra_params
+        options = Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").sendgrid_options
 
-        extra["send_at"].should eq(1704067200_i64)
+        options["send_at"].should eq(JSON::Any.new(1704067200_i64))
       end
 
       it "does not include send_at when not defined" do
         email = FakeEmail.new(text_body: "0")
-        extra = Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").extra_params
+        options = Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").sendgrid_options
 
-        extra.has_key?("send_at").should eq(false)
+        options.has_key?("send_at").should eq(false)
+      end
+
+      it "includes asm in sendgrid_options when defined" do
+        custom_email = CustomTemplateEmail.new
+        options = Carbon::SendGridAdapter::Email.new(custom_email, api_key: "fake_key").sendgrid_options
+
+        options["asm"].should eq(JSON.parse({"group_id" => 1234, "groups_to_display" => [1234]}.to_json))
+      end
+
+      it "does not include asm when not defined" do
+        email = FakeEmail.new(text_body: "0")
+        options = Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").sendgrid_options
+
+        options.has_key?("asm").should eq(false)
+      end
+
+      it "includes template_id in sendgrid_options when defined" do
+        custom_email = CustomTemplateEmail.new
+        options = Carbon::SendGridAdapter::Email.new(custom_email, api_key: "fake_key").sendgrid_options
+
+        options["template_id"].should eq(JSON::Any.new("welcome-abc-123"))
+      end
+
+      it "includes content in sendgrid_options when template_id not defined" do
+        email = FakeEmail.new(text_body: "hello")
+        options = Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").sendgrid_options
+
+        options["content"].should eq(JSON.parse([{"type" => "text/plain", "value" => "hello"}].to_json))
+        options.has_key?("template_id").should eq(false)
       end
     end
   end
@@ -200,6 +229,11 @@ end
 private def params_for(**email_attrs)
   email = FakeEmail.new(**email_attrs)
   Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").params
+end
+
+private def sendgrid_options_for(**email_attrs)
+  email = FakeEmail.new(**email_attrs)
+  Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").sendgrid_options
 end
 
 private def send_email_to_send_grid(**email_attrs)

--- a/spec/carbon_sendgrid_adapter_spec.cr
+++ b/spec/carbon_sendgrid_adapter_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "./support/email_with_sendgrid_features"
 
 describe Carbon::SendGridAdapter do
   {% if flag?("with-integration") %}
@@ -162,6 +163,36 @@ describe Carbon::SendGridAdapter do
       attachments.size.should eq(1)
       attachments.first["filename"].should eq("contract.pdf")
       Base64.decode_string(attachments.first["content"].to_s).should eq("Sign here")
+    end
+
+    describe "sendgrid specific features" do
+      it "includes categories in extra_params when defined" do
+        email = EmailWithSendGridFeatures.new(text_body: "0")
+        extra = Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").extra_params
+
+        extra["categories"].should eq(["welcome", "onboarding", "transactional"])
+      end
+
+      it "does not include categories when not defined" do
+        email = FakeEmail.new(text_body: "0")
+        extra = Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").extra_params
+
+        extra.has_key?("categories").should eq(false)
+      end
+
+      it "includes send_at in extra_params when defined" do
+        email = EmailWithSendGridFeatures.new(text_body: "0")
+        extra = Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").extra_params
+
+        extra["send_at"].should eq(1704067200_i64)
+      end
+
+      it "does not include send_at when not defined" do
+        email = FakeEmail.new(text_body: "0")
+        extra = Carbon::SendGridAdapter::Email.new(email, api_key: "fake_key").extra_params
+
+        extra.has_key?("send_at").should eq(false)
+      end
     end
   end
 end

--- a/spec/support/custom_template_email.cr
+++ b/spec/support/custom_template_email.cr
@@ -15,10 +15,10 @@ class CustomTemplateEmail < Carbon::Email
     "welcome-abc-123"
   end
 
-  def asm_data
+  def asm
     {
-      "group_id"          => 12345,
-      "groups_to_display" => [12345],
+      "group_id"          => 1234,
+      "groups_to_display" => [1234],
     }
   end
 

--- a/spec/support/custom_template_email.cr
+++ b/spec/support/custom_template_email.cr
@@ -7,7 +7,7 @@ class CustomTemplateEmail < Carbon::Email
     @headers = {} of String => String,
     @subject = "subject",
     @text_body : String? = nil,
-    @html_body : String? = nil
+    @html_body : String? = nil,
   )
   end
 

--- a/spec/support/email_with_sendgrid_features.cr
+++ b/spec/support/email_with_sendgrid_features.cr
@@ -1,0 +1,39 @@
+class EmailWithSendGridFeatures < Carbon::Email
+  getter text_body, html_body
+
+  def initialize(
+    @from = Carbon::Address.new("from@example.com"),
+    @to = [] of Carbon::Address,
+    @cc = [] of Carbon::Address,
+    @bcc = [] of Carbon::Address,
+    @headers = {} of String => String,
+    @subject = "subject",
+    @text_body : String? = nil,
+    @html_body : String? = nil,
+  )
+  end
+
+  def template_id
+    "d-1234567890"
+  end
+
+  def dynamic_template_data
+    {
+      "name" => "Test User",
+    }
+  end
+
+  def categories : Array(String)
+    ["welcome", "onboarding", "transactional"]
+  end
+
+  def send_at : Int64
+    1704067200_i64 # 2024-01-01 00:00:00 UTC
+  end
+
+  from @from
+  to @to
+  cc @cc
+  bcc @bcc
+  subject @subject
+end

--- a/spec/support/fake_email.cr
+++ b/spec/support/fake_email.cr
@@ -9,7 +9,7 @@ class FakeEmail < Carbon::Email
     @headers = {} of String => String,
     @subject = "subject",
     @text_body : String? = nil,
-    @html_body : String? = nil
+    @html_body : String? = nil,
   )
   end
 

--- a/spec/support/fake_email_with_attachments.cr
+++ b/spec/support/fake_email_with_attachments.cr
@@ -9,7 +9,7 @@ class FakeEmailWithAttachments < Carbon::Email
     @headers = {} of String => String,
     @subject = "subject",
     @text_body : String? = nil,
-    @html_body : String? = nil
+    @html_body : String? = nil,
   )
   end
 

--- a/src/carbon_sendgrid_extensions.cr
+++ b/src/carbon_sendgrid_extensions.cr
@@ -24,6 +24,20 @@ module Carbon::SendGridExtensions
   def asm
     nil
   end
+
+  # Define categories for your email to organize
+  # and track analytics by category.
+  # https://docs.sendgrid.com/ui/analytics-and-reporting/categories
+  def categories : Array(String)?
+    nil
+  end
+
+  # Define a unix timestamp to schedule when
+  # the email should be sent.
+  # https://docs.sendgrid.com/ui/sending-email/scheduling-parameters
+  def send_at : Int64?
+    nil
+  end
 end
 
 class Carbon::Email


### PR DESCRIPTION
## Summary
Adds support for SendGrid's `categories` and `send_at` API parameters, allowing emails to be organized by category for analytics and scheduled for future delivery.

Closes #13

## Changes
- Add `categories` and `send_at` extension methods to `Carbon::SendGridExtensions`
- Consolidate all SendGrid-specific optional fields into `sendgrid_options` method for consistent handling
- Separate core email structure (`params`) from SendGrid API-specific options (`sendgrid_options`)
- Add comprehensive tests for both features
- Add `EmailWithSendGridFeatures` test fixture

## Code Organization
Previously, SendGrid-specific fields were inconsistently handled between `params` (for `asm`, `template_id`, `content`) and `extra_params` (for `categories`, `send_at`). This has been refactored so:
- **`params`**: Core email structure only (personalizations, subject, from, headers, reply_to, mail_settings, attachments)
- **`sendgrid_options`**: All SendGrid-specific optional fields (asm, template_id/content, categories, send_at)
- **`deliver`**: Cleanly merges both hashes into the final JSON payload
This improves maintainability and makes it clear where new SendGrid features should be added.

## Usage
```crystal
class WelcomeEmail < Carbon::Email
  def categories : Array(String)
    ["welcome", "onboarding", "transactional"]
  end
  def send_at : Int64
    1704067200_i64  # Unix timestamp
  end
  # ... rest of email config
end
```